### PR TITLE
ops: fix nodejs workflow

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -29,5 +29,6 @@ jobs:
           version: 8
           
       - run: pnpm install --frozen-lockfile
+      - run: pnpm lint
       - run: pnpm test
       - run: pnpm build

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -4,31 +4,27 @@
 name: Node.js CI
 
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+  - push
+  - pull_request
 
 jobs:
-  build:
-
+  install-and-build:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [18.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
     steps:
-    - uses: pnpm/action-setup@v3
-      with:
-        version: 8
-    - uses: actions/checkout@v3
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'npm'
-    - run: pnpm install
-    - run: pnpm test
-    - run: pnpm build --if-present
+      - name: Checkout
+        uses: actions/checkout@v4
+        
+      - name: Install Node.js 18
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+  
+      - name: Install pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 8
+          
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm test
+      - run: pnpm build --if-present

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -30,4 +30,4 @@ jobs:
           
       - run: pnpm install --frozen-lockfile
       - run: pnpm test
-      - run: pnpm build --if-present
+      - run: pnpm build

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   install-and-build:
     runs-on: ubuntu-latest
+    env:
+      DATABASE_CLIENT: sqlite
+      DATABASE_URL: db/test.db
 
     steps:
       - name: Checkout


### PR DESCRIPTION
# fix:  nodejs workflow

The Nodejs workflow configuration had an issue with `actions/setup-node@v3` where it wasn't able to check and use `pnpm-lock.yaml` as in v3 it did not consider it a valid `lockfile`.

## Fix

We are updating it to use `actions/setup-nodev4` instead and while at it upgrading `actions/checkout@v4` as well.

## Workflow steps

Steps:
- Install `Nodejs` version 18
- Install `pnpm`
- Run tests
- Run build